### PR TITLE
Typo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Pegasus docs
+
 ```sh
 pip install mkdocs mkdocs-cinder pygments pymdown-extensions
 mkdocs serve

--- a/docs/dev/build.md
+++ b/docs/dev/build.md
@@ -18,7 +18,7 @@ Pegasus is a cross-platform native application written in C++ and built mainly o
 
 To **install Qt**, you can follow the guide on [this page](install-qt.md).<br/>
 To **install SDL2**, you can use your platform's package manager or you can download the library directly from its [official site](https://www.libsdl.org/download-2.0.php).<br/>
-To **install Git**, use your platform's package manager, or the [official installer](https://git-scm.com/downloads), and make sure it's avalable in your `PATH`.
+To **install Git**, use your platform's package manager, or the [official installer](https://git-scm.com/downloads), and make sure it's available in your `PATH`.
 
 
 ## The build process

--- a/docs/dev/deploy.md
+++ b/docs/dev/deploy.md
@@ -37,4 +37,4 @@ windeployqt
 
 ## macOS
 
-`make` creates a regular `.app` release. Similarly to Linux, you can use it as-is for static builds, or use `macdeployqt` to collect the liraries and optionally generate a DMG file.
+`make` creates a regular `.app` release. Similarly to Linux, you can use it as-is for static builds, or use `macdeployqt` to collect the libraries and optionally generate a DMG file.

--- a/docs/dev/install-qt.md
+++ b/docs/dev/install-qt.md
@@ -1,6 +1,6 @@
 # Installing Qt for desktop
 
-Qt is a cross-platform application framework used by Pegasus. At least Qt 5.9 is requred, with 5.12 or later recommended for better performance on embedded platforms. For desktop platforms you can get the Qt tools using their installer:
+Qt is a cross-platform application framework used by Pegasus. At least Qt 5.9 is required, with 5.12 or later recommended for better performance on embedded platforms. For desktop platforms you can get the Qt tools using their installer:
 
 <a href="https://www1.qt.io/download-open-source/"><button type="button" class="btn btn-success"><i class="fa fa-cloud-download"></i> &nbsp; Download the Qt installer</button></a>
 

--- a/docs/dev/translate.md
+++ b/docs/dev/translate.md
@@ -53,7 +53,7 @@ Then, create a copy of `pegasus_en.ts`, and change `en` to your locale's code (s
 
 Open your new file in a text editor or in Qt Linguist.
 
-If you're using a **text editor**, the translateable strings are inside `<message>` tags: you can see the original text in the `<source>` tag, and you can provide your translation in `<translation>`. Also change the language tag on the top of the file (`<TS ...>`).
+If you're using a **text editor**, the translatable strings are inside `<message>` tags: you can see the original text in the `<source>` tag, and you can provide your translation in `<translation>`. Also change the language tag on the top of the file (`<TS ...>`).
 
 If you're using **Qt Linguist**, first set your language in *Edit -> Translation file settings -> Target language*. After that, you can select a "module" (group of texts) on the left, then see the relevant strings in the upper-middle panel. You can add the translation in the center panel (marked with "1" on the picture above). Then press the green checkmark on the top toolbar (or press Ctrl+Enter) to jump to the next untranslated line.
 
@@ -61,7 +61,7 @@ A detailed guide for Qt Linguist can be found [here](https://doc.qt.io/qt-5/ling
 
 !!! help
     - `%1`, `%2`, ... in the text is a placeholder for additional values, such as numbers, file names, etc.
-    - screenshots for most of the translateable text can be found [here](https://imgur.com/a/no3Jm)
+    - screenshots for most of the translatable text can be found [here](https://imgur.com/a/no3Jm)
 
 ## 4. (optional) Rebuild Pegasus and test the translation
 

--- a/docs/themes/api.md
+++ b/docs/themes/api.md
@@ -16,7 +16,7 @@ Games found by Pegasus are organized in collections, and one game may be present
 Property | Description
 ---|---
 `name` | The unique name of the collection, eg. "Nintendo Entertainment System", "Mario Cartridges", etc.
-`sortBy` | A variation of the collections's name that should be used for sorting. By default, it's the same as `name`.
+`sortBy` | A variation of the collections' name that should be used for sorting. By default, it's the same as `name`.
 `shortName` | <span class="optional"></span> A short name for the collection, often an abbreviation like `nes`, `mame`, etc. Always in lowercase. If not set, defaults to the value of `name`.
 `summary` | <span class="optional"></span> Short description (typically 2-3 sentences).
 `description` | <span class="optional"></span> Longer description.
@@ -215,11 +215,11 @@ function launchGame(game) {
 
 ## Device
 
-Some themes might want to display information about the real world, like current time or battery status. The `api.device` object provides some fields for that. Hovewer, as Pegasus is available for a number of various devices, note that not all features may be available on all platforms.
+Some themes might want to display information about the real world, like current time or battery status. The `api.device` object provides some fields for that. However, as Pegasus is available for a number of various devices, note that not all features may be available on all platforms.
 
 Property | Description
 ---------|------------
-`batteryCharging` | A boolean (true/false) value, telling whether the device is currently chaging its battery. If there's no battery, or the device doesn't support this property, the value will be `false`.
+`batteryCharging` | A boolean (true/false) value, telling whether the device is currently charging its battery. If there's no battery, or the device doesn't support this property, the value will be `false`.
 `batteryPercent` | The percentage of battery life left, as a fractional value between `0.0` (0%) and `1.0` (100%). If there's no battery, or the device doesn't support this property, the value will be `NaN` (not-a-number). You can use [isNaN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isNaN) to check this.
 `batterySeconds` | The remaining battery time, in seconds. If the device is charging, there's no battery, or the device doesn't support this property, the value will be 0 or negative.
 

--- a/docs/themes/example-flixnet-ch2.md
+++ b/docs/themes/example-flixnet-ch2.md
@@ -54,7 +54,7 @@ ListView {
 
 ## Horizontal scroll
 
-We have a somewhat complex layout -- scrollable items inside a scrollable item; we can't just set `focus: true` here, since that'd mean we set it for *each* row, and end up with scrolling one we don't want. Hovewer, every `ListView` has select-next and select-previous function we can use (`incrementCurrentIndex()`, `decrementCurrentIndex()`), and the currently selected item can be accessed through `currentItem`.
+We have a somewhat complex layout -- scrollable items inside a scrollable item; we can't just set `focus: true` here, since that'd mean we set it for *each* row, and end up with scrolling one we don't want. However, every `ListView` has select-next and select-previous function we can use (`incrementCurrentIndex()`, `decrementCurrentIndex()`), and the currently selected item can be accessed through `currentItem`.
 
 In this case, the `currentItem` of `collectionAxis` will be the `Item` element inside `collectionAxisDelegate`:
 

--- a/docs/themes/example-flixnet-ch4.md
+++ b/docs/themes/example-flixnet-ch4.md
@@ -33,7 +33,7 @@ Component {
 }
 ```
 
-So which image asset should we use? A game box is a rectangle with 16:9 aspect ratio, so the `banner` would be perfect for this. However, since every asset is potentially missing, we should consider showing other images and provide multiple fallback assets. If we don't have a `banner`, the next similarly sized one is the `steam` ("grid icon") asset. Because it's wider than 16:9, we'll need to crop it if we don't want black bars or squashed/ stretched images (though you might prefer that). If neither image is available, I'll use `boxFront` as it tends to be commonly available.
+So which image asset should we use? A game box is a rectangle with 16:9 aspect ratio, so the `banner` would be perfect for this. However, since every asset is potentially missing, we should consider showing other images and provide multiple fallbacks. If we don't have a `banner`, the next similarly sized one is the `steam` ("grid icon") asset. Because it's wider than 16:9, we'll need to crop it if we don't want black bars or squashed/stretched images (though you might prefer that). If neither image is available, I'll use `boxFront` as it tends to be commonly available.
 
 Let's extend the Image object created previously:
 

--- a/docs/themes/example-flixnet-ch4.md
+++ b/docs/themes/example-flixnet-ch4.md
@@ -33,7 +33,7 @@ Component {
 }
 ```
 
-So which image asset should we use? A game box is a rectangle with 16:9 aspect ratio, so the `banner` would be perfect for this. However, since every asset is potentially missing, we should consider showing other images and provide multiple fallbacks. If we don't have a `banner`, the next similarly sized one is the `steam` ("grid icon") asset. Because it's wider than 16:9, we'll need to crop it if we don't want black bars or squashed/scretched images (though you might prefer that). If neither image is available, I'll use `boxFront` as it tends to be commonly available.
+So which image asset should we use? A game box is a rectangle with 16:9 aspect ratio, so the `banner` would be perfect for this. However, since every asset is potentially missing, we should consider showing other images and provide multiple fallback assets. If we don't have a `banner`, the next similarly sized one is the `steam` ("grid icon") asset. Because it's wider than 16:9, we'll need to crop it if we don't want black bars or squashed/ stretched images (though you might prefer that). If neither image is available, I'll use `boxFront` as it tends to be commonly available.
 
 Let's extend the Image object created previously:
 
@@ -224,7 +224,7 @@ The horizontal scrolling works similarly, with one important difference: there i
 
 <video autoplay loop style="max-width:100%;display:block;margin:0 auto"><source src="../webm/flixnet_pathview2.webm" type="video/webm"></video>
 
-I've set the left margin previously to 100 px and the width of a game box to be 240x135. In addition, there's a 10px spacing between the elements, giving the full width of a box to 250. The center of the current-item would be at 100 + 250/2 = 225 on the path, but to make it align with the collection label, I'll shift it 5px (half of the spacing) to the left, making the X center to be 220px. Then counting backwards, the previous-item will be at 220 - 250, and the one before that (the leftmost postion, where the new elements will appear when scrolling) at 220 - 250 * 2.
+I've set the left margin previously to 100 px and the width of a game box to be 240x135. In addition, there's a 10px spacing between the elements, giving the full width of a box to 250. The center of the current-item would be at 100 + 250/2 = 225 on the path, but to make it align with the collection label, I'll shift it 5px (half of the spacing) to the left, making the X center to be 220px. Then counting backwards, the previous-item will be at 220 - 250, and the one before that (the leftmost position, where the new elements will appear when scrolling) at 220 - 250 * 2.
 
 All right, let's change the horizontal ListView into a PathView:
 

--- a/docs/themes/example-flixnet-ch5.md
+++ b/docs/themes/example-flixnet-ch5.md
@@ -30,7 +30,7 @@ Text {
 
 The rating will be displayed as a five-star bar, with some percentage of it colored according to the actual rating. This can be done with two simple, overlapping QML Images: draw five empty stars first, then over them, draw filled ones according to the rating. Kind of like a progress bar, except we're using stars for filling.
 
-But first of all, I actuatlly draw two images for the stars, an empty one and a filled. Both have square size and transparent background. I create a new directory (eg. `assets`) in my theme folder and put them there.
+But first of all, I actually draw two images for the stars, an empty one and a filled. Both have square size and transparent background. I create a new directory (eg. `assets`) in my theme folder and put them there.
 
 star_empty.svg | star_filled.svg
 :---: | :----:

--- a/docs/themes/example-simple-ch2.md
+++ b/docs/themes/example-simple-ch2.md
@@ -42,7 +42,7 @@ FocusScope {
 
 ### Collection logo
 
-Lets's add the collection's logo to the panel. First you'll need a bunch of game system logo images. I've borrowed them from EmulationStation (original: Nils Bonenberger, CC-BY-NC-SA), except the RetroPie logo (original: Florian Müller, CC-BY-NC-SA). You can get them [here](https://github.com/mmatyas/pegasus-frontend/releases/download/alpha1/logos.zip). The file names match the system names from EmulationStation. Simply create a new directory inside your theme's folder, eg. `assets`, and extract them there.
+Lets add the collection's logo to the panel. First you'll need a bunch of game system logo images. I've borrowed them from EmulationStation (original: Nils Bonenberger, CC-BY-NC-SA), except the RetroPie logo (original: Florian Müller, CC-BY-NC-SA). You can get them [here](https://github.com/mmatyas/pegasus-frontend/releases/download/alpha1/logos.zip). The file names match the system names from EmulationStation. Simply create a new directory inside your theme's folder, eg. `assets`, and extract them there.
 
 After that, I add an Image element inside the `menu` Rectangle:
 
@@ -128,7 +128,7 @@ After a refresh, pressing ++left++ and ++right++ should now change the logo on t
     Handling keyboard keys also enables gamepad navigation. See the [controls](../user-guide/controls) page about how keys and buttons are related.
 
 !!! tip
-    Often there are mmore than one way to solve problems. Instead of manually handling the collection index, I could have used a ListView. We do that in the [Flixnet tutorial](example-flixnet-intro.md), and also for the game list.
+    Often there are more than one way to solve problems. Instead of manually handling the collection index, I could have used a ListView. We do that in the [Flixnet tutorial](example-flixnet-intro.md), and also for the game list.
 
 ### Game list
 

--- a/docs/themes/example-simple-ch3.md
+++ b/docs/themes/example-simple-ch3.md
@@ -65,7 +65,7 @@ Rectangle {
 }
 ```
 
-Box art images might be quite big in resolution, so this time I've also set `sourceSize`: it limits the maximum amount of memory the image will take up. If the image is largen than this, it will be scaled down, keeping the aspect ratio. In this particular case, I've set it to scale down to 1024 &times; 1024 pixels (taking up about/at most 1024 &times; 1024 &times; 3 bytes = 3 MiB space in the memory).
+Box art images might be quite big in resolution, so this time I've also set `sourceSize`: it limits the maximum amount of memory the image will take up. If the image is larger than this, it will be scaled down, keeping the aspect ratio. In this particular case, I've set it to scale down to 1024 &times; 1024 pixels (taking up about/at most 1024 &times; 1024 &times; 3 bytes = 3 MiB space in the memory).
 
 !!! note "Column and Row"
     The QML Column and Row object are great tools for aligning a fixed number of elements. In this case, the box art and the further Text items could be put into a Column that would `anchors.fill` its parent with a 50px `anchors.margin`, so I wouldn't have to define it for the Image itself and the other Texts.
@@ -157,7 +157,7 @@ Note that I only show the year when it's greater than 0. If we have no informati
 
 ### Description
 
-A multiline text area. If the game has a short summar, it'll show that, otherwise the detailed description (or stay empty if none is available).
+A multiline text area. If the game has a short summary, it'll show that, otherwise the detailed description (or stay empty if none is available).
 
 ```qml
 Rectangle {

--- a/docs/themes/qml-tutorials.md
+++ b/docs/themes/qml-tutorials.md
@@ -23,7 +23,7 @@ These provide an introduction to the language. After reading them, you should be
 
 ## Dynamic layout
 
-A theme should be able to show the list of games and collections. An array of data objects is what QML calls "Model". You can fully customize how one item should look like on the screen (the "Delegate"), and how all these items should be aligned/ laid out (the "View").
+A theme should be able to show the list of games and collections. An array of data objects is what QML calls "Model". You can fully customize how one item should look like on the screen (the "Delegate"), and how all these items should be aligned/laid out (the "View").
 
 The standard layouts are:
 

--- a/docs/themes/qml-tutorials.md
+++ b/docs/themes/qml-tutorials.md
@@ -23,12 +23,12 @@ These provide an introduction to the language. After reading them, you should be
 
 ## Dynamic layout
 
-A theme should be able to show the list of games and collections. An array of data objects is what QML calls "Model". You can fully customize how one item should look like on the screen (the "Delegate"), and how all these items should be aligned/layed out (the "View").
+A theme should be able to show the list of games and collections. An array of data objects is what QML calls "Model". You can fully customize how one item should look like on the screen (the "Delegate"), and how all these items should be aligned/ laid out (the "View").
 
 The standard layouts are:
 
 - [ListView](https://doc.qt.io/qt-5/qml-qtquick-listview.html): aligns the items on a horizontal or vertical path
-- [GridView](https://doc.qt.io/qt-5/qml-qtquick-gridview.html): fills a grid with the items (either the number rows or the number of colums should be specified)
+- [GridView](https://doc.qt.io/qt-5/qml-qtquick-gridview.html): fills a grid with the items (either the number rows or the number of columns should be specified)
 - [PathView](https://doc.qt.io/qt-5/qml-qtquick-pathview.html): aligns the items along an arbitrary path
 - [Repeater](https://doc.qt.io/qt-5/qml-qtquick-repeater.html): simply creates the items but doesn't do any further alignment
 

--- a/docs/user-guide/meta-files.md
+++ b/docs/user-guide/meta-files.md
@@ -254,7 +254,7 @@ You can add various assets (eg. cover art) for your games. This is documented [H
 
 ## Real-world examples
 
-You can find some more exaples on the platform specific pages:
+You can find some more examples on the platform specific pages:
 
 - [Windows](platform-windows.md)
 - [Android](platform-android.md)

--- a/docs/user-guide/platform-android.md
+++ b/docs/user-guide/platform-android.md
@@ -16,7 +16,7 @@ Config files are stored under `<storage>/pegasus-frontend`, where `<storage>` th
 
 Pegasus can be set as the default launcher, which will make it start automatically when the device is turned on. After installing Pegasus, when you press the home screen button a popup message should appear, asking you which launcher you would like to run. Select Pegasus (or your previous launcher) from the list to set it as the default launcher.
 
-**To restore the default launcher**, open the Android Settings menu, either from Pegasus or by pulling down the noticfication bar at the top of the screen and clicking the cogwheel icon. Depending on your device, you should find a "Default launcher" option in either under *Apps &rarr; Advanced settings &rarr; Default apps*, *Apps &rarr; Configure apps* or *Home*.
+**To restore the default launcher**, open the Android Settings menu, either from Pegasus or by pulling down the notification bar at the top of the screen and clicking the cogwheel icon. Depending on your device, you should find a "Default launcher" option in either under *Apps &rarr; Advanced settings &rarr; Default apps*, *Apps &rarr; Configure apps* or *Home*.
 
 ## Loading games
 
@@ -53,7 +53,7 @@ launch: am start --user 0
     The full documentation of `am` can be found [here](https://developer.android.com/studio/command-line/adb#am) and [here](https://developer.android.com/studio/command-line/adb#IntentSpec).<br>
     If you're not familiar with Pegasus' config files, you can find their documentation [here](meta-files.md).
 
-Note that not every app supports opening arbitrary files, or opening files at all (for example, RetroArch). In addition, there seems to be a glich on some systems where a file may get opened with something else when there are multiple apps that can handle the file type. Which leads to...
+Note that not every app supports opening arbitrary files, or opening files at all (for example, RetroArch). In addition, there seems to be a glitch on some systems where a file may get opened with something else when there are multiple apps that can handle the file type. Which leads to...
 
 ### Open a file with a specific app
 
@@ -137,7 +137,7 @@ launch: am start --user 0
 
 The important parts here are the **core** and the **storage** paths. Make sure you **correct the paths** of the above example to match your system and collection:
 
-- `/storage/emulated/0` is the absolute path to the internal storage on my phone. This can be completely different on other devices (eg. `/storage/sdcard`). Most file browser apps can tell you the correct path, then you can replace all occurences above.
+- `/storage/emulated/0` is the absolute path to the internal storage on my phone. This can be completely different on other devices (eg. `/storage/sdcard`). Most file browser apps can tell you the correct path, then you can replace all occurrences above.
 - `/data/data/com.retroarch/cores/fceumm_libretro_android.so` is the libretro core I've installed using the RetroArch menu. You'll only need to change the `fceumm_libretro_android.so` part. You can find the available cores [here](http://buildbot.libretro.com/nightly/android/latest/armeabi-v7a/).
 - If you've created a custom configuration file inside RetroArch, you can change `CONFIGFILE` to point to that instead of the default.
 
@@ -186,4 +186,4 @@ SuperRetro16 Lite | `com.bubblezapgames.supergnes_lite/com.bubblezapgames.superg
 - Video playback has a high battery drain
 - Unmounting the SD card while Pegasus is running may force close it
 - If you're launching a memory-intensive application, the Android OS may decide to close Pegasus
-- Shutdown and reboot are not avaliable due to Android restrictions
+- Shutdown and reboot are not available due to Android restrictions


### PR DESCRIPTION
This PR fixes a few typos which existed in the current documentation. I've also added a header to the top-level README to keep [Markdown lint](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md041---first-line-in-a-file-should-be-a-top-level-heading) happy.