### PR TITLE
Add missing build dependency

### DIFF
--- a/docs/dev/install-qt.md
+++ b/docs/dev/install-qt.md
@@ -33,6 +33,7 @@ On many Linux distros, the Qt libraries in the official repositories are often s
 
 - `qtdeclarative5-dev`
 - `qtmultimedia5-dev`
+- `qttools5-dev-tools`
 - `libqt5gamepad5-dev`
 - `libqt5svg5-dev`
 - `qml-module-qtgraphicaleffects`

--- a/docs/dev/install-qt.md
+++ b/docs/dev/install-qt.md
@@ -31,12 +31,12 @@ On many Linux distros, the Qt libraries in the official repositories are often s
 
 **Debian 10** (buster) and **Ubuntu 19.04** or later contains up-to-date Qt releases, so building Pegasus should be possible using the following packages:
 
-- `qtdeclarative5-dev`
-- `qtmultimedia5-dev`
-- `qttools5-dev-tools`
 - `libqt5gamepad5-dev`
 - `libqt5svg5-dev`
 - `qml-module-qtgraphicaleffects`
+- `qtdeclarative5-dev`
+- `qtmultimedia5-dev`
+- `qttools5-dev-tools`
 
 **Earlier releases** contain an up-to-date Qt release, but miss a few necessary packages. You can either use the Qt installer (see above), or use the following PPA:
 


### PR DESCRIPTION
The `qttools5-dev-tools` build dependency package was missing.

I have also sorted the dependencies alphabetically.