### PR TITLE
Add qml-module-qtmultimedia to list of Debian/Ubuntu build requirements.

### DIFF
--- a/docs/dev/install-qt.md
+++ b/docs/dev/install-qt.md
@@ -36,6 +36,7 @@ On many Linux distros, the Qt libraries in the official repositories are often s
 - `qml-module-qtgraphicaleffects`
 - `qtdeclarative5-dev`
 - `qtmultimedia5-dev`
+- `qml-module-qtmultimedia`
 - `qttools5-dev-tools`
 
 **Earlier releases** contain an up-to-date Qt release, but miss a few necessary packages. You can either use the Qt installer (see above), or use the following PPA:

--- a/docs/dev/install-qt.md
+++ b/docs/dev/install-qt.md
@@ -34,9 +34,9 @@ On many Linux distros, the Qt libraries in the official repositories are often s
 - `libqt5gamepad5-dev`
 - `libqt5svg5-dev`
 - `qml-module-qtgraphicaleffects`
+- `qml-module-qtmultimedia`
 - `qtdeclarative5-dev`
 - `qtmultimedia5-dev`
-- `qml-module-qtmultimedia`
 - `qttools5-dev-tools`
 
 **Earlier releases** contain an up-to-date Qt release, but miss a few necessary packages. You can either use the Qt installer (see above), or use the following PPA:


### PR DESCRIPTION
Themes (certainly Pegasus Grid) require qml-module-qtmultimedia. If this package isn't installed, the compiled pegasus-fe binary won't be able to run with the built-in theme.