### PR TITLE
Add Flatpak default directory

### DIFF
--- a/docs/user-guide/config-dirs.md
+++ b/docs/user-guide/config-dirs.md
@@ -8,6 +8,7 @@ Platform | Directory
 ---------|----------
 **all platforms:** | `<directory of the program>/config`
 **Linux:** | `~/.config/pegasus-frontend/`
+**Linux (Flatpak):** | `~/home/[username]/.var/app/org.pegasus_frontend.Pegasus/config/`
 **Windows:** | `C:\Users\[username]\AppData\Local\pegasus-frontend\`
 **macOS:** | `~/Library/Preferences/pegasus-frontend/`
 **Android:** | `<storage>/pegasus-frontend/`

--- a/docs/user-guide/config-dirs.md
+++ b/docs/user-guide/config-dirs.md
@@ -8,7 +8,7 @@ Platform | Directory
 ---------|----------
 **all platforms:** | `<directory of the program>/config`
 **Linux:** | `~/.config/pegasus-frontend/`
-**Linux (Flatpak):** | `~/home/[username]/.var/app/org.pegasus_frontend.Pegasus/config/pegasus-frontend/`
+**Linux (Flatpak):** | `~/.var/app/org.pegasus_frontend.Pegasus/config/pegasus-frontend/`
 **Windows:** | `C:\Users\[username]\AppData\Local\pegasus-frontend\`
 **macOS:** | `~/Library/Preferences/pegasus-frontend/`
 **Android:** | `<storage>/pegasus-frontend/`

--- a/docs/user-guide/config-dirs.md
+++ b/docs/user-guide/config-dirs.md
@@ -8,7 +8,7 @@ Platform | Directory
 ---------|----------
 **all platforms:** | `<directory of the program>/config`
 **Linux:** | `~/.config/pegasus-frontend/`
-**Linux (Flatpak):** | `~/home/[username]/.var/app/org.pegasus_frontend.Pegasus/config/`
+**Linux (Flatpak):** | `~/home/[username]/.var/app/org.pegasus_frontend.Pegasus/config/pegasus-frontend/`
 **Windows:** | `C:\Users\[username]\AppData\Local\pegasus-frontend\`
 **macOS:** | `~/Library/Preferences/pegasus-frontend/`
 **Android:** | `<storage>/pegasus-frontend/`

--- a/docs/user-guide/installing-themes.md
+++ b/docs/user-guide/installing-themes.md
@@ -3,7 +3,7 @@
 Themes are stored in the `themes` directory. The default location of that is:
 
 - **Linux:** `~/.config/pegasus-frontend/themes/`
-- **Linux (Flatpak):** `~/home/[username]/.var/app/org.pegasus_frontend.Pegasus/config/themes/`
+- **Linux (Flatpak):** `~/home/[username]/.var/app/org.pegasus_frontend.Pegasus/config/pegasus-frontend/themes/`
 - **Windows:** `C:\Users\[username]\AppData\Local\pegasus-frontend\themes\`
 - **macOS:** `~/Library/Preferences/pegasus-frontend/themes/`
 - **Android:** `<storage>/pegasus-frontend/themes/`

--- a/docs/user-guide/installing-themes.md
+++ b/docs/user-guide/installing-themes.md
@@ -3,7 +3,7 @@
 Themes are stored in the `themes` directory. The default location of that is:
 
 - **Linux:** `~/.config/pegasus-frontend/themes/`
-- **Linux (Flatpak):** `~/home/[username]/.var/app/org.pegasus_frontend.Pegasus/config/pegasus-frontend/themes/`
+- **Linux (Flatpak):** `~/.var/app/org.pegasus_frontend.Pegasus/config/pegasus-frontend/themes/`
 - **Windows:** `C:\Users\[username]\AppData\Local\pegasus-frontend\themes\`
 - **macOS:** `~/Library/Preferences/pegasus-frontend/themes/`
 - **Android:** `<storage>/pegasus-frontend/themes/`

--- a/docs/user-guide/installing-themes.md
+++ b/docs/user-guide/installing-themes.md
@@ -3,6 +3,7 @@
 Themes are stored in the `themes` directory. The default location of that is:
 
 - **Linux:** `~/.config/pegasus-frontend/themes/`
+- **Linux (Flatpak):** `~/home/[username]/.var/app/org.pegasus_frontend.Pegasus/config/themes/`
 - **Windows:** `C:\Users\[username]\AppData\Local\pegasus-frontend\themes\`
 - **macOS:** `~/Library/Preferences/pegasus-frontend/themes/`
 - **Android:** `<storage>/pegasus-frontend/themes/`


### PR DESCRIPTION
- Add Flatpak default directory path in `Config directories` page
- Add Flatpak default directory path in `Installing themes` page