### PR TITLE
Improve Android launch commands

### DIFF
--- a/docs/user-guide/platform-android-example.md
+++ b/docs/user-guide/platform-android-example.md
@@ -62,14 +62,10 @@ Now I create a [metadata file](meta-files.md) for each system. As mentioned in t
           -e ROM {file.path}
           -e LIBRETRO /data/data/com.retroarch/cores/fceumm_libretro_android.so
           -e CONFIGFILE /storage/emulated/0/Android/data/com.retroarch/files/retroarch.cfg
-          -e IME com.android.inputmethod.latin/.LatinIME
-          -e DATADIR /data/data/com.retroarch
-          -e APK /data/app/com.retroarch-1/base.apk
-          -e SDCARD /storage/emulated/0
-          -e DOWNLOADS /storage/emulated/0/Download
-          -e SCREENSHOTS /storage/emulated/0/Pictures
-          -e EXTERNAL /storage/emulated/0/Android/data/com.retroarch/files
+          -e QUITFOCUS
           --activity-clear-top
+          --activity-clear-task
+          --activity-no-history
 
 !!! warning "SD card path"
     In the above configurations I use `/storage/emulated/0/` which is the path of the SD card on my device. This might be different for you! You can check the path in most file manager apps, look for something like "file details" or similar.

--- a/docs/user-guide/platform-android.md
+++ b/docs/user-guide/platform-android.md
@@ -105,7 +105,9 @@ launch: am start --user 0
   -e LIBRETRO /data/data/com.retroarch/cores/fceumm_libretro_android.so
   -e CONFIGFILE /storage/emulated/0/Android/data/com.retroarch/files/retroarch.cfg
   -e QUITFOCUS
-  --activity-single-top
+  --activity-clear-top
+  --activity-clear-task
+  --activity-no-history
 ```
 
 #### RetroArch64/RetroArch Plus (AArch64):
@@ -119,7 +121,9 @@ launch: am start --user 0
   -e LIBRETRO /data/data/com.retroarch.aarch64/cores/fceumm_libretro_android.so
   -e CONFIGFILE /storage/emulated/0/Android/data/com.retroarch.aarch64/files/retroarch.cfg
   -e QUITFOCUS
-  --activity-single-top
+  --activity-clear-top
+  --activity-clear-task
+  --activity-no-history
 ```
 
 (based on the source code of their Android port at the time of writing).

--- a/docs/user-guide/platform-android.md
+++ b/docs/user-guide/platform-android.md
@@ -104,12 +104,8 @@ launch: am start --user 0
   -e ROM {file.path}
   -e LIBRETRO /data/data/com.retroarch/cores/fceumm_libretro_android.so
   -e CONFIGFILE /storage/emulated/0/Android/data/com.retroarch/files/retroarch.cfg
-  -e IME com.android.inputmethod.latin/.LatinIME
-  -e DATADIR /data/data/com.retroarch
-  -e APK /data/app/com.retroarch-1/base.apk
-  -e SDCARD /storage/emulated/0
-  -e EXTERNAL /storage/emulated/0/Android/data/com.retroarch/files
-  --activity-clear-top
+  -e QUITFOCUS
+  --activity-single-top
 ```
 
 #### RetroArch64/RetroArch Plus (AArch64):
@@ -122,12 +118,8 @@ launch: am start --user 0
   -e ROM {file.path}
   -e LIBRETRO /data/data/com.retroarch.aarch64/cores/fceumm_libretro_android.so
   -e CONFIGFILE /storage/emulated/0/Android/data/com.retroarch.aarch64/files/retroarch.cfg
-  -e IME com.android.inputmethod.latin/.LatinIME
-  -e DATADIR /data/data/com.retroarch.aarch64
-  -e APK /data/app/com.retroarch.aarch64-1/base.apk
-  -e SDCARD /storage/emulated/0
-  -e EXTERNAL /storage/emulated/0/Android/data/com.retroarch.aarch64/files
-  --activity-clear-top
+  -e QUITFOCUS
+  --activity-single-top
 ```
 
 (based on the source code of their Android port at the time of writing).


### PR DESCRIPTION
I have tested Pegasus on my Retroid Pocket 2+, running Android 9, and I have simplified the Android launch commands to make them less confusing to newcomers.

* The `IME`, `DATADIR`, `APK`, `SDCARD`, and `EXTERNAL` flags are all non-essential
* `--activity-single-top` ensures there is only one RetroArch task (it doesn't seem to load new tasks with different intents anyway)
* `QUITFOCUS` means that if another app is brought into the foreground, RetroArch quits. This is particularly useful if your Android device has a home button, as it means the game is quit properly when a new game is launched from Pegasus, and it doesn't simply resume the old game.